### PR TITLE
Limit the number of characters on a single line

### DIFF
--- a/lib/jsminify.js
+++ b/lib/jsminify.js
@@ -58,7 +58,12 @@ exports.jsminify = function (code, config, callback) {
 
         code = uglify.gen_code(ast, config);
 
-        //First pass with comma (comment inside code somewhere
+        //Limit the number of characters on a single line
+        if (!config.beautify && config.max_line_length) {
+            code = uglify.split_lines(code, config.max_line_length);
+        }
+
+        //First pass with comma (comment inside code somewhere)
         code = code.replace(reTokens1, function () {
             return '\n' + comments.shift() + '\n';
         });
@@ -72,11 +77,11 @@ exports.jsminify = function (code, config, callback) {
             (code.substr(code.length - 1) === '}')) {
             code += ';';
         }
-        code += '\n';
 
-        if (!config.beautify && config.max_line_length) {
-            code = uglify.split_lines(code, config.max_line_length);
-        }
+        //Trim spaces at the beginning of the code
+        code = code.replace(/^\s+/, '');
+
+        code += '\n';
 
         callback(null, code);
     } catch (e) {


### PR DESCRIPTION
UglifyJS `gen_code` does not call `split_lines` automatically.
The command-line tool calls it: https://github.com/mishoo/UglifyJS/blob/master/bin/uglifyjs#L316
In addition, removed the empty lines at the beginning of the compressed code (before the first preserved comment).
