### PR TITLE
Use a minimal function declaration as the token string to replace preserved comment block 

### DIFF
--- a/lib/jsminify.js
+++ b/lib/jsminify.js
@@ -29,9 +29,9 @@ exports.jsminify = function (code, config, callback) {
     }
     config = config || exports.config;
     var comments = [],
-        token = 'switch("yUglify: preserved comment block"){}',
+        token = 'function fn(){"yUglify: preserved comment block";}',
         reMultiComments = /\/\*![\s\S]*?\*\//g,
-        reTokens = new RegExp(token.replace(/[(){}]/g, '\\$&'), 'g'),
+        reTokens = new RegExp('function \\w+\\(\\)\\{\\"yUglify: preserved comment block\\";\\}', 'g'),
         ast;
 
     try {


### PR DESCRIPTION
When a preserved comment block is followed by an IIFE, the minified js doesn't pass syntax parsing, like closure compiler, because of missing brackets around the IIFE in minified js file.

For example: 

``` javascript
/*! important comment */

/**
 * @module Test
 */
(function() {
    console.log('test');
}());
```

The snippet above is a minimal version of a yui 2 module, when wrapped as a yui2in3 module, including YUI2 variable and version information at the bottom, minified version could be:

``` javascript
YUI.add("yui2-Test",function(e,t){var n=e.YUI2;
/*! important comment */
function(){console.log("test")}()},"@VERSION@");
```

However, the minified result doesn't compile in closure compiler , neither does it in any browser.
Errors in closure compiler:
JSC_PARSE_ERROR: Parse error. syntax error at line 4 character 32
function(){console.log("test")}()},"@VERSION@");
                                ^
JSC_PARSE_ERROR: Parse error. missing } after function body at line 4 character 47
function(){console.log("test")}()},"@VERSION@");
                                               ^
The missing brackets around the IIFE is the cause.

The deeper reason behind this is that yuglify uses a simple string as the token to replace the preserved comment, i.e.:

``` javascript
token = '"yUglify: preserved comment block"'
```

If preserved comment block is followed by an IIFE, after uglify minifies the js file, in which preserved comments has been replaced with tokens, it adds a comma between the token string and the IIFE and removes the surrounding brackets of the IIFE, because uglify **joins consecutive simple statements into sequences using the “comma operator”**. (if I understand correctly after a deep debugging.) 

Therefore instead of using a simple string as the token and handles the inconsistency that sometimes it adds comma sometimes it doesn't, a minimal _function_ could be a better alternative: 

``` javascript
token = 'function fn(){"yUglify: preserved comment block";}'
```

and the uglify result is consistent for all the cases. And of course it fixes the IIFE after preserved comment block:

``` javascript
YUI.add("yui2-Test",function(e,t){var n=e.YUI2;
/*! important comment */
(function(){console.log("test")})()},"@VERSION@");
```

It requires a minor fix of shifter's tests, which requires another PR https://github.com/yui/shifter/pull/97.
